### PR TITLE
fix: create DOI if missing

### DIFF
--- a/ied-editor.js
+++ b/ied-editor.js
@@ -84,9 +84,9 @@ export class IedEditor extends LitElement {
     }
 
     const edits = [];
-    let instance = ln.querySelector(`:scope > [name="${path[0].name}"]`);
-    for (let i = 1; i < path.length; i += 1) {
-      let nextInstance = instance.querySelector(
+    let instance = ln;
+    for (let i = 0; i < path.length; i += 1) {
+      let nextInstance = instance?.querySelector(
         `:scope > [name="${path[i].name}"]`,
       );
       if (!nextInstance) {


### PR DESCRIPTION
This fixes a bug where a missing DOI caused a `TypeError: Cannot read properties of null (reading 'querySelector')` in `ied-editor.js:89` when trying to instantiate a nested `LN -> DOI -> DAI` path to a `Val` to be inserted.