### PR TITLE
Refactor the IED editor into components and utilities

### DIFF
--- a/src/components/ied-search-filter.ts
+++ b/src/components/ied-search-filter.ts
@@ -1,0 +1,417 @@
+import { LitElement, html, css } from 'lit';
+import { property, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+
+import { identity } from '@openenergytools/scl-lib';
+import {
+  dataModelPathCache,
+  debounce,
+  getDataModel,
+  getInitializedEltPath,
+  matchesLNToken,
+  matchesNameToken,
+  pathHasPrefixAndTokens,
+} from '../utils/ied-data-model.js';
+
+import '@material/web/textfield/outlined-text-field.js';
+import '@material/web/iconbutton/outlined-icon-button.js';
+import '@material/web/icon/icon.js';
+import '@material/web/radio/radio.js';
+
+export interface SearchChangedDetail {
+  searchTerm: string;
+  pathsToRender: string[];
+}
+
+export class IedSearchFilter extends LitElement {
+  @property({ type: Object }) doc?: Document;
+
+  @property({ type: Object }) ied?: Element;
+
+  @state() private searchTerm = '';
+
+  @state() private searchScope: 'all' | 'instances' = 'all';
+
+  @state() private searchSettingsOpen = false;
+
+  protected updated(changed: Map<string, unknown>) {
+    super.updated?.(changed);
+    if (changed.has('ied') || changed.has('doc')) {
+      this.searchTerm = '';
+      const searchInput = this.shadowRoot?.querySelector(
+        '.search-input',
+      ) as HTMLInputElement | null;
+      if (searchInput) searchInput.value = '';
+    }
+  }
+
+  private parseSearchTokens(): string[] {
+    return this.searchTerm.trim().split(/\s+/).filter(Boolean);
+  }
+
+  private searchSelectorIED(): Element[] {
+    if (!this.ied) return [];
+
+    const lowerCaseTerm = this.searchTerm.toLowerCase();
+    const attributes = ['inst', 'desc', 'lnClass', 'lnType'];
+
+    return Array.from(
+      this.ied.querySelectorAll(':scope > AccessPoint > Server *'),
+    ).filter(elt =>
+      attributes.some(attr =>
+        elt.getAttribute(attr)?.toLowerCase().includes(lowerCaseTerm),
+      ),
+    );
+  }
+
+  private searchSelectorIEDValues(): Element[] {
+    if (!this.ied) return [];
+
+    const lowerCaseTerm = this.searchTerm.toLowerCase();
+
+    const matchingDais = Array.from(
+      this.ied.querySelectorAll(':scope > AccessPoint > Server DAI > Val'),
+    )
+      .filter(val => val.textContent?.toLowerCase().includes(lowerCaseTerm))
+      .map(val => val.parentElement!);
+
+    return [...new Set(matchingDais)];
+  }
+
+  private searchSelectorTemplates(): Element[] {
+    if (!this.doc) return [];
+
+    const lowerCaseTerm = this.searchTerm.toLowerCase();
+    const attributes = [
+      'id',
+      'lnClass',
+      'desc',
+      'name',
+      'type',
+      'cdc',
+      'fc',
+      'bType',
+    ];
+
+    return Array.from(
+      this.doc.querySelectorAll(':root > DataTypeTemplates *'),
+    ).filter(elt =>
+      attributes.some(attr =>
+        elt.getAttribute(attr)?.toLowerCase().includes(lowerCaseTerm),
+      ),
+    );
+  }
+
+  private searchHierarchicalIED(tokens: string[]): Element[] {
+    if (!this.ied) return [];
+
+    const [firstToken, ...restTokens] = tokens;
+
+    // Start with all LN/LN0 elements matching the first token (or all if wildcard)
+    let currentLevel: Element[] = Array.from(
+      this.ied.querySelectorAll(
+        ':scope > AccessPoint > Server > LDevice > LN, :scope > AccessPoint > Server > LDevice > LN0',
+      ),
+    ).filter(ln => matchesLNToken(ln, firstToken));
+
+    // Iteratively narrow to children matching subsequent tokens
+    for (const token of restTokens) {
+      currentLevel = currentLevel.flatMap(parent =>
+        Array.from(parent.children)
+          .filter(child => ['DOI', 'SDI', 'DAI'].includes(child.tagName))
+          .filter(child => matchesNameToken(child, token)),
+      );
+
+      // If no matches at this level, stop searching further
+      if (currentLevel.length === 0) break;
+    }
+
+    // Return all matched elements and their descendants so the full subtree renders
+    return [
+      ...currentLevel,
+      ...currentLevel.flatMap(el =>
+        Array.from(el.querySelectorAll('DOI, SDI, DAI')),
+      ),
+    ];
+  }
+
+  private searchHierarchicalTemplates(tokens: string[]): string[] {
+    if (!this.ied || !this.doc) return [];
+
+    const [firstToken, ...nameTokens] = tokens;
+
+    // Find all LN instances matching the first token to determine relevant template paths
+    const lnPaths: string[] = [];
+    Array.from(
+      this.ied.querySelectorAll(
+        ':scope > AccessPoint > Server > LDevice > LN, :scope > AccessPoint > Server > LDevice > LN0',
+      ),
+    )
+      .filter(ln => firstToken === '*' || matchesLNToken(ln, firstToken))
+      .forEach(ln => {
+        const lnTypeId = ln.getAttribute('lnType');
+        if (!lnTypeId) return;
+        const lnType = this.doc!.querySelector(
+          `:root > DataTypeTemplates > LNodeType[id="${lnTypeId}"]`,
+        );
+        if (!lnType) return;
+        const lnPath = `${ln.tagName} ${identity(ln)}`;
+        lnPaths.push(lnPath);
+        getDataModel(lnType, [lnPath]);
+      });
+
+    if (lnPaths.length === 0) return [];
+
+    // Check cached paths for all template elements against the relevant LN paths and token sequence
+    const matchingPaths: string[] = [];
+    Array.from(
+      this.doc.querySelectorAll(':root > DataTypeTemplates *'),
+    ).forEach(element => {
+      const cachedPaths = dataModelPathCache.get(element) as
+        | Set<string>
+        | undefined;
+      if (!cachedPaths || cachedPaths.size === 0) return;
+      [...cachedPaths].forEach(path => {
+        if (
+          !matchingPaths.includes(path) &&
+          lnPaths.some(lnPath =>
+            pathHasPrefixAndTokens(path, lnPath, nameTokens),
+          )
+        ) {
+          matchingPaths.push(path);
+        }
+      });
+    });
+
+    return matchingPaths;
+  }
+
+  private performSearch(searchTerm: string) {
+    this.searchTerm = searchTerm;
+    const newPathsToRender: string[] = [];
+    if (!this.ied || !this.doc) return;
+
+    const tokens = this.parseSearchTokens();
+    const useInstances = true;
+    const useTemplates = this.searchScope !== 'instances';
+
+    const addPath = (path: string) => {
+      if (!newPathsToRender.includes(path)) newPathsToRender.push(path);
+    };
+
+    if (tokens.length > 1) {
+      if (useInstances) {
+        this.searchHierarchicalIED(tokens).forEach(element => {
+          if (['DOI', 'SDI', 'DAI'].includes(element.tagName)) {
+            addPath(getInitializedEltPath(element));
+          }
+        });
+      }
+
+      if (useTemplates) {
+        this.searchHierarchicalTemplates(tokens).forEach(addPath);
+      }
+    } else {
+      [
+        ...(useInstances ? this.searchSelectorIED() : []),
+        ...(useInstances ? this.searchSelectorIEDValues() : []),
+        ...(useTemplates ? this.searchSelectorTemplates() : []),
+      ].forEach(element => {
+        if (element.tagName === 'LDevice') {
+          addPath(identity(element) as string);
+        } else if (['DOI', 'SDI', 'DAI'].includes(element.tagName)) {
+          addPath(getInitializedEltPath(element));
+        }
+
+        dataModelPathCache
+          .get(element)
+          ?.forEach((path: string) => addPath(path));
+      });
+    }
+
+    this.dispatchEvent(
+      new CustomEvent<SearchChangedDetail>('search-changed', {
+        detail: { searchTerm, pathsToRender: newPathsToRender },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private debounceSearch = debounce((...args: unknown[]) => {
+    this.performSearch(args[0] as string);
+  });
+
+  private resetSearch() {
+    const searchInput = this.shadowRoot?.querySelector(
+      '.search-input',
+    ) as HTMLInputElement;
+    if (searchInput) searchInput.value = '';
+    this.performSearch('');
+  }
+
+  private toggleSearchSettings() {
+    this.searchSettingsOpen = !this.searchSettingsOpen;
+  }
+
+  render() {
+    return html`
+      <div class="search-container">
+        <div
+          class="${classMap({
+            'search-field': true,
+            'has-term': !!this.searchTerm,
+          })}"
+        >
+          <md-icon class="search-icon" slot="leading-icon">search</md-icon>
+          <md-outlined-text-field
+            class="search-input"
+            label="Search"
+            @input=${(e: Event) => {
+              const searchInput = (e.target as HTMLInputElement)?.value;
+              this.debounceSearch(searchInput);
+            }}
+          >
+          </md-outlined-text-field>
+          <md-outlined-icon-button
+            aria-label="Clear search"
+            title="Clear search"
+            class="clear-btn"
+            ?disabled=${!this.searchTerm}
+            @click=${() => this.resetSearch()}
+          >
+            <md-icon>clear</md-icon>
+          </md-outlined-icon-button>
+          <md-outlined-icon-button
+            aria-label="Search settings"
+            title="Search settings"
+            @click=${() => this.toggleSearchSettings()}
+            ><md-icon
+              >${this.searchSettingsOpen
+                ? 'filter_alt_off'
+                : 'filter_alt'}</md-icon
+            ></md-outlined-icon-button
+          >
+        </div>
+        <div
+          class="${classMap({
+            'search-settings': true,
+            open: this.searchSettingsOpen,
+          })}"
+        >
+          <p>Scope:</p>
+          <div id="search-mode">
+            ${(
+              [
+                ['all', 'All'],
+                ['instances', 'Instantiated'],
+              ] as const
+            ).map(
+              ([value, label]) => html`
+                <label>
+                  <md-radio
+                    name="search-scope"
+                    value=${value}
+                    ?checked=${this.searchScope === value}
+                    @change=${() => {
+                      this.searchScope = value;
+                      this.performSearch(this.searchTerm);
+                    }}
+                  ></md-radio>
+                  ${label}
+                </label>
+              `,
+            )}
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  static styles = css`
+    :host {
+      --md-outlined-icon-button-size: 24px;
+      --md-outlined-icon-button-container-shape: 10px;
+
+      --md-outlined-text-field-top-space: 8px;
+      --md-outlined-text-field-bottom-space: 8px;
+    }
+
+    .search-container {
+      width: fit-content;
+      background: var(--oscd-base3);
+      border-radius: 10px;
+    }
+
+    .search-field {
+      display: flex;
+      align-items: center;
+      width: max-content;
+      padding: 0.5rem;
+    }
+
+    .search-field .search-icon {
+      padding: 0 8px;
+    }
+
+    .clear-btn {
+      max-width: 0;
+      overflow: hidden;
+      opacity: 0;
+      transition:
+        max-width 0.2s ease,
+        opacity 0.2s ease;
+    }
+
+    .has-term .clear-btn {
+      max-width: 40px;
+      opacity: 1;
+      margin-right: 0.5rem;
+    }
+
+    .search-input {
+      width: 400px;
+      min-width: 0;
+      transition: width 0.2s ease;
+      margin: 0 0.5rem;
+    }
+
+    .has-term .search-input {
+      width: 376px;
+    }
+
+    .search-settings {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      padding: 0 1rem;
+      overflow: hidden;
+      max-height: 0;
+      transition: max-height 0.25s ease-out;
+    }
+
+    .search-settings.open {
+      max-height: 4rem;
+      transition: max-height 0.25s ease-in;
+    }
+
+    .search-settings p {
+      font-family: var(--oscd-theme-text-font);
+      font-weight: bold;
+    }
+
+    #search-mode {
+      display: flex;
+      align-self: center;
+      align-items: center;
+      gap: 1rem;
+    }
+
+    label {
+      font-family: var(--oscd-theme-text-font);
+      color: var(--oscd-base01);
+    }
+  `;
+}
+
+customElements.define('ied-search-filter', IedSearchFilter);

--- a/src/ied-editor.ts
+++ b/src/ied-editor.ts
@@ -11,27 +11,24 @@ import {
   SetTextContent,
 } from '@omicronenergy/oscd-api';
 import { newEditEventV2 } from '@omicronenergy/oscd-api/utils.js';
+
 import {
-  dataModelPathCache,
   DataModel,
-  debounce,
   getDataModel,
   getInitializedEltPath,
-  matchesLNToken,
-  matchesNameToken,
-  pathHasPrefixAndTokens,
 } from './utils/ied-data-model.js';
+
+import type { EditField } from './components/edit-dialog.js';
+import type { SearchChangedDetail } from './components/ied-search-filter.js';
 
 import 'mbg-val-input/mbg-val-input.js';
 import './components/alert-dialog.js';
 import './components/edit-dialog.js';
-import type { EditField } from './components/edit-dialog.js';
+import './components/ied-search-filter.js';
 
 import '@material/web/textfield/filled-text-field.js';
 import '@material/web/iconbutton/icon-button.js';
-import '@material/web/iconbutton/outlined-icon-button.js';
 import '@material/web/icon/icon.js';
-import '@material/web/radio/radio.js';
 import '@material/web/progress/circular-progress.js';
 import '@material/web/dialog/dialog.js';
 import '@material/web/button/text-button.js';
@@ -211,10 +208,6 @@ export class IedEditor extends LitElement {
 
   @property({ type: Boolean }) loadingIED = false;
 
-  @state() private searchScope: 'all' | 'instances' = 'all';
-
-  @state() private searchSettingsOpen = false;
-
   @state() private pendingDeleteLN: Element | null = null;
 
   @state() private pendingDeleteFCDAs: Element[] = [];
@@ -254,208 +247,9 @@ export class IedEditor extends LitElement {
     }
   }
 
-  private parseSearchTokens(): string[] {
-    return this.searchTerm.trim().split(/\s+/).filter(Boolean);
-  }
-
-  private searchSelectorIED() {
-    if (!this.ied) return [];
-
-    const lowerCaseTerm = this.searchTerm.toLowerCase();
-    const attributes = ['inst', 'desc', 'lnClass', 'lnType'];
-
-    return Array.from(
-      this.ied.querySelectorAll(':scope > AccessPoint > Server *'),
-    ).filter(elt =>
-      attributes.some(attr =>
-        elt.getAttribute(attr)?.toLowerCase().includes(lowerCaseTerm),
-      ),
-    );
-  }
-
-  private searchSelectorIEDValues(): Element[] {
-    if (!this.ied) return [];
-
-    const lowerCaseTerm = this.searchTerm.toLowerCase();
-
-    const matchingDais = Array.from(
-      this.ied.querySelectorAll(':scope > AccessPoint > Server DAI > Val'),
-    )
-      .filter(val => val.textContent?.toLowerCase().includes(lowerCaseTerm))
-      .map(val => val.parentElement!);
-
-    return [...new Set(matchingDais)];
-  }
-
-  private searchSelectorTemplates() {
-    if (!this.doc) return [];
-
-    const lowerCaseTerm = this.searchTerm.toLowerCase();
-    const attributes = [
-      'id',
-      'lnClass',
-      'desc',
-      'name',
-      'type',
-      'cdc',
-      'fc',
-      'bType',
-    ];
-
-    return Array.from(
-      this.doc.querySelectorAll(':root > DataTypeTemplates *'),
-    ).filter(elt =>
-      attributes.some(attr =>
-        elt.getAttribute(attr)?.toLowerCase().includes(lowerCaseTerm),
-      ),
-    );
-  }
-
-  private searchHierarchicalIED(tokens: string[]): Element[] {
-    if (!this.ied) return [];
-
-    const [firstToken, ...restTokens] = tokens;
-
-    // Start with all LN/LN0 elements matching the first token (or all if wildcard)
-    let currentLevel: Element[] = Array.from(
-      this.ied.querySelectorAll(
-        ':scope > AccessPoint > Server > LDevice > LN, :scope > AccessPoint > Server > LDevice > LN0',
-      ),
-    ).filter(ln => matchesLNToken(ln, firstToken));
-
-    // Iteratively narrow to children matching subsequent tokens, stopping if no matches at any level
-    for (const token of restTokens) {
-      currentLevel = currentLevel.flatMap(parent =>
-        Array.from(parent.children)
-          .filter(child => ['DOI', 'SDI', 'DAI'].includes(child.tagName))
-          .filter(child => matchesNameToken(child, token)),
-      );
-      if (currentLevel.length === 0) break;
-    }
-
-    // Return all matched elements and their DOI/SDI/DAI descendants so the full subtree renders
-    return [
-      ...currentLevel,
-      ...currentLevel.flatMap(el =>
-        Array.from(el.querySelectorAll('DOI, SDI, DAI')),
-      ),
-    ];
-  }
-
-  private searchHierarchicalTemplates(tokens: string[]): string[] {
-    if (!this.ied || !this.doc) return [];
-
-    const [firstToken, ...nameTokens] = tokens;
-
-    // Find all LN instances matching the first token to determine relevant template paths to consider from the cache
-    const lnPaths: string[] = [];
-    Array.from(
-      this.ied.querySelectorAll(
-        ':scope > AccessPoint > Server > LDevice > LN, :scope > AccessPoint > Server > LDevice > LN0',
-      ),
-    )
-      .filter(ln => firstToken === '*' || matchesLNToken(ln, firstToken))
-      .forEach(ln => {
-        const lnTypeId = ln.getAttribute('lnType');
-        if (!lnTypeId) return;
-        const lnType = this.doc!.querySelector(
-          `:root > DataTypeTemplates > LNodeType[id="${lnTypeId}"]`,
-        );
-        if (!lnType) return;
-        const lnPath = `${ln.tagName} ${identity(ln)}`;
-        lnPaths.push(lnPath);
-        getDataModel(lnType, [lnPath]);
-      });
-
-    if (lnPaths.length === 0) return [];
-
-    // Check cached paths for all template elements against the relevant LN paths and token sequence
-    const matchingPaths: string[] = [];
-    Array.from(
-      this.doc.querySelectorAll(':root > DataTypeTemplates *'),
-    ).forEach(element => {
-      const cachedPaths = dataModelPathCache.get(element) as
-        | Set<string>
-        | undefined;
-      if (!cachedPaths || cachedPaths.size === 0) return;
-      [...cachedPaths].forEach(path => {
-        if (
-          !matchingPaths.includes(path) &&
-          lnPaths.some(lnPath =>
-            pathHasPrefixAndTokens(path, lnPath, nameTokens),
-          )
-        ) {
-          matchingPaths.push(path);
-        }
-      });
-    });
-
-    return matchingPaths;
-  }
-
-  private performSearch(searchTerm: string) {
-    this.searchTerm = searchTerm;
-    const newPathsToRender: string[] = [];
-    if (!this.ied || !this.doc) return;
-
-    const tokens = this.parseSearchTokens();
-    const useInstances = true;
-    const useTemplates = this.searchScope !== 'instances';
-
-    const addPath = (path: string) => {
-      if (!newPathsToRender.includes(path)) newPathsToRender.push(path);
-    };
-
-    if (tokens.length > 1) {
-      if (useInstances) {
-        this.searchHierarchicalIED(tokens).forEach(element => {
-          if (['DOI', 'SDI', 'DAI'].includes(element.tagName)) {
-            addPath(getInitializedEltPath(element));
-          }
-        });
-      }
-      if (useTemplates) {
-        this.searchHierarchicalTemplates(tokens).forEach(addPath);
-      }
-    } else {
-      [
-        ...(useInstances ? this.searchSelectorIED() : []),
-        ...(useInstances ? this.searchSelectorIEDValues() : []),
-        ...(useTemplates ? this.searchSelectorTemplates() : []),
-      ].forEach(element => {
-        if (element.tagName === 'LDevice') {
-          addPath(identity(element) as string);
-        } else if (['DOI', 'SDI', 'DAI'].includes(element.tagName)) {
-          addPath(getInitializedEltPath(element));
-        }
-        dataModelPathCache
-          .get(element)
-          ?.forEach((path: string) => addPath(path));
-      });
-    }
-
-    this.pathsToRender = newPathsToRender;
-    this.requestUpdate();
-  }
-
-  private debounceSearch = debounce((...args: unknown[]) => {
-    const term = args[0] as string;
-    this.performSearch(term);
-  });
-
-  private resetSearch() {
-    this.searchTerm = '';
-
-    const searchInput = this.shadowRoot?.querySelector(
-      '.search-input',
-    ) as HTMLInputElement;
-    searchInput.value = '';
-
-    this.requestUpdate();
-  }
-
-  private toggleSearchSettings() {
-    this.searchSettingsOpen = !this.searchSettingsOpen;
+  private handleSearchChanged(e: CustomEvent<SearchChangedDetail>) {
+    this.searchTerm = e.detail.searchTerm;
+    this.pathsToRender = e.detail.pathsToRender;
   }
 
   private instantiatePath(path: { name: string; tag: string }[], ln: Element) {
@@ -1392,77 +1186,11 @@ export class IedEditor extends LitElement {
             </div>
           </main>`
         : html`<main>
-            <div class="search-container">
-              <div
-                class="${classMap({
-                  'search-field': true,
-                  'has-term': !!this.searchTerm,
-                })}"
-              >
-                <md-icon class="search-icon" slot="leading-icon"
-                  >search</md-icon
-                >
-                <md-outlined-text-field
-                  class="search-input"
-                  label="Search"
-                  @input=${(e: Event) => {
-                    const searchInput = (e.target as HTMLInputElement)?.value;
-                    this.debounceSearch(searchInput);
-                  }}
-                >
-                </md-outlined-text-field>
-                <md-outlined-icon-button
-                  aria-label="Clear search"
-                  title="Clear search"
-                  class="clear-btn"
-                  ?disabled=${!this.searchTerm}
-                  @click=${() => this.resetSearch()}
-                >
-                  <md-icon>clear</md-icon>
-                </md-outlined-icon-button>
-                <md-outlined-icon-button
-                  aria-label="Search settings"
-                  title="Search settings"
-                  @click=${() => this.toggleSearchSettings()}
-                  ><md-icon
-                    >${this.searchSettingsOpen
-                      ? 'filter_alt_off'
-                      : 'filter_alt'}</md-icon
-                  ></md-outlined-icon-button
-                >
-              </div>
-              <div
-                class="${classMap({
-                  'search-settings': true,
-                  open: this.searchSettingsOpen,
-                })}"
-              >
-                <p>Scope:</p>
-                <div id="search-mode">
-                  ${(
-                    [
-                      ['all', 'All'],
-                      ['instances', 'Instantiated'],
-                    ] as const
-                  ).map(
-                    ([value, label]) => html`
-                      <label>
-                        <md-radio
-                          name="search-scope"
-                          value=${value}
-                          ?checked=${this.searchScope === value}
-                          @change=${() => {
-                            this.searchScope = value;
-                            this.performSearch(this.searchTerm);
-                          }}
-                        ></md-radio>
-                        ${label}
-                      </label>
-                    `,
-                  )}
-                </div>
-              </div>
-            </div>
+            <ied-search-filter
+              .doc=${this.doc}
+              .ied=${this.ied}
+              @search-changed=${this.handleSearchChanged}
+            ></ied-search-filter>
 
             ${Array.from(
               this.ied?.querySelectorAll(':scope > AccessPoint > Server') ?? [],
@@ -1569,84 +1297,6 @@ export class IedEditor extends LitElement {
 
     md-filled-text-field {
       width: 300px;
-    }
-
-    .search-container {
-      width: fit-content;
-      background: var(--oscd-base3);
-      border-radius: 10px;
-    }
-
-    .search-field {
-      display: flex;
-      align-items: center;
-      width: max-content;
-      padding: 0.5rem;
-    }
-
-    .search-field .search-icon {
-      padding: 0 8px;
-    }
-
-    .clear-btn {
-      max-width: 0;
-      overflow: hidden;
-      opacity: 0;
-      transition:
-        max-width 0.2s ease,
-        opacity 0.2s ease;
-    }
-
-    .has-term .clear-btn {
-      max-width: 40px;
-      opacity: 1;
-      margin-right: 0.5rem;
-    }
-
-    .search-input {
-      width: 400px;
-      min-width: 0;
-      transition: width 0.2s ease;
-      margin: 0 0.5rem;
-
-      --md-outlined-text-field-top-space: 8px;
-      --md-outlined-text-field-bottom-space: 8px;
-    }
-
-    .has-term .search-input {
-      width: 376px;
-    }
-
-    .search-settings {
-      display: flex;
-      align-items: center;
-      gap: 1rem;
-      padding: 0 1rem;
-      overflow: hidden;
-      max-height: 0;
-      transition: max-height 0.25s ease-out;
-    }
-
-    .search-settings.open {
-      max-height: 4rem;
-      transition: max-height 0.25s ease-in;
-    }
-
-    .search-settings p {
-      font-family: var(--oscd-theme-text-font);
-      font-weight: bold;
-    }
-
-    #search-mode {
-      display: flex;
-      align-self: center;
-      align-items: center;
-      gap: 1rem;
-    }
-
-    label {
-      font-family: var(--oscd-theme-text-font);
-      color: var(--oscd-base01);
     }
 
     details {

--- a/src/ied-editor.ts
+++ b/src/ied-editor.ts
@@ -21,6 +21,18 @@ import {
   getInitializedEltPath,
 } from './utils/ied-data-model.js';
 
+import {
+  findInstanceToRemove,
+  getInputPath,
+  getInstanceDescription,
+  getMostNestedElement,
+  getSGCB,
+  getTemplateDescription,
+  getTemplateValue,
+  isReadOnly,
+  setTag,
+} from './utils/ied-scl.js';
+
 import type { EditField } from './components/edit-dialog.js';
 import type { SearchChangedDetail } from './components/ied-search-filter.js';
 
@@ -66,24 +78,6 @@ function handleModelExpand(e: Event) {
   }
 }
 
-function getInputPath(
-  ln: Element,
-  path: { name: string; tag: string }[],
-  sGroup: string,
-) {
-  const parentLD = (ln.parentNode as Element)?.getAttribute('inst');
-  const lnClass = ln.getAttribute('lnClass');
-  const lnInst = ln.getAttribute('inst');
-
-  let elementID = `${parentLD}-${lnClass}${lnInst}`;
-  for (let i = 0; i < path.length; i += 1) {
-    elementID += `-${path[i].name}`;
-    if (i === path.length - 1) elementID += sGroup;
-  }
-
-  return elementID;
-}
-
 function renderDataModelSpan(key: Element) {
   if (key.nodeName === 'DA' || key.nodeName === 'BDA') {
     return html`<span class="type"
@@ -97,61 +91,6 @@ function renderDataModelSpan(key: Element) {
     >${key.nodeName}
     <span class="subtype">(${key.getAttribute('type')})</span></span
   >`;
-}
-
-function findInstanceToRemove(element: Element) {
-  const parent = element.parentElement as Element;
-  const siblings = Array.from(parent.children).filter(
-    child => child.tagName === element.tagName,
-  );
-
-  if (siblings.length > 1 || !['DOI', 'SDI', 'DAI'].includes(parent.tagName)) {
-    return element;
-  }
-
-  return findInstanceToRemove(parent);
-}
-
-function getSGCB(ld: Element): Element | null {
-  if (ld.querySelector(':scope > LN0 > SettingControl')) {
-    return ld.querySelector(':scope > LN0 > SettingControl') as Element;
-  }
-
-  if (!ld.querySelector(':scope > LN0 > DOI[name="GrRef"]')) {
-    return null;
-  }
-
-  const setSrcRef = ld.querySelector(
-    ':scope > LN0 > DOI[name="GrRef"] > DAI[name="setSrcRef"] > Val',
-  );
-  const sgcbRef = setSrcRef?.textContent?.trim().replace(/^@/, '') ?? '';
-  const ldRef = ld
-    .closest('Server')!
-    .querySelector(`:scope > LDevice[inst="${sgcbRef}"]`);
-
-  return getSGCB(ldRef as Element);
-}
-
-function setTag(key: Element) {
-  let tag = 'DAI';
-
-  if (key.tagName === 'DO') {
-    tag = 'DOI';
-  } else if (key.tagName === 'SDO' || key.getAttribute('bType') === 'Struct') {
-    tag = 'SDI';
-  }
-
-  return tag;
-}
-
-function isReadOnly(da: Element | null): boolean {
-  if (!da) return false;
-
-  const isKindRO = (da.getAttribute('valKind') as string) === 'RO';
-  if (!da.getAttribute('valImport')) return isKindRO;
-
-  const canImport = (da.getAttribute('valImport') as string) === 'false';
-  return isKindRO && canImport;
 }
 
 export class IedEditor extends LitElement {
@@ -208,6 +147,10 @@ export class IedEditor extends LitElement {
     }
   }
 
+  private get dataTypeTemplates(): Element {
+    return this.doc?.querySelector(`:root > DataTypeTemplates`) as Element;
+  }
+
   private handleSearchChanged(e: CustomEvent<SearchChangedDetail>) {
     this.searchTerm = e.detail.searchTerm;
     this.pathsToRender = e.detail.pathsToRender;
@@ -242,108 +185,6 @@ export class IedEditor extends LitElement {
     }
 
     return { parent: instance, edits };
-  }
-
-  private getTemplateValue(ln: Element, path: { name: string; tag: string }[]) {
-    const template = this.doc?.querySelector(`:root > DataTypeTemplates`);
-    const lnTemplate = template?.querySelector(
-      `:scope > LNodeType[id="${ln.getAttribute('lnType')}"]`,
-    );
-    let nestedInst = lnTemplate?.querySelector(
-      `:scope > *[name="${path[0].name}"]`,
-    );
-
-    for (let i = 1; i < path.length; i += 1) {
-      const instType = nestedInst?.getAttribute('type');
-      const instTemplate = template?.querySelector(
-        `:scope > *[id="${instType}"]`,
-      );
-      nestedInst = instTemplate?.querySelector(
-        `:scope > *[name="${path[i].name}"]`,
-      );
-    }
-
-    if (nestedInst?.querySelector('Val')) {
-      return nestedInst?.querySelector('Val')?.textContent;
-    }
-
-    return '';
-  }
-
-  private getInstanceDescription(
-    target: Element,
-    host?: Element,
-    path: { name: string; tag: string }[] = [],
-  ) {
-    // if the instance is in a path, check if it has a description in the IED
-    let instantiatedDesc = '';
-    if (path.length > 0 && host) {
-      let childInstance = host.querySelector(
-        `:scope > DOI[name="${path[0].name}"]`,
-      );
-      for (let i = 1; i < path.length && childInstance; i += 1) {
-        childInstance = childInstance.querySelector(
-          `:scope > *[name="${path[i].name}"]`,
-        );
-      }
-
-      if (childInstance?.getAttribute('name') === target.getAttribute('name')) {
-        instantiatedDesc = childInstance?.getAttribute('desc') ?? '';
-      }
-    }
-
-    if (instantiatedDesc) {
-      return html`<p class="desc">${instantiatedDesc}</p>`;
-    }
-
-    // check if the instance itself has a description
-    if (target.getAttribute('desc')) {
-      return html`<p class="desc">${target.getAttribute('desc')}</p>`;
-    }
-
-    // check if the template has a description
-    const template = this.doc?.querySelector(`:root > DataTypeTemplates`);
-    let instTemplate = null;
-    if (target.nodeName === 'LN' || target.nodeName === 'LN0') {
-      instTemplate = template?.querySelector(
-        `:scope > LNodeType[id="${target.getAttribute('lnType')}"]`,
-      );
-    } else if (target.nodeName !== 'LDevice') {
-      instTemplate = template?.querySelector(
-        `:scope > *[id="${target.getAttribute('type')}"]`,
-      );
-    }
-
-    if (instTemplate?.getAttribute('desc')) {
-      return html`<p class="desc">${instTemplate?.getAttribute('desc')}</p>`;
-    }
-
-    return nothing;
-  }
-
-  private getMostNestedElt(
-    path: { name: string; tag: string }[],
-    lnType: string,
-  ): Element | null {
-    let parentName = path[0].name;
-    let parentElt = this.doc?.querySelector(
-      `:root > DataTypeTemplates > LNodeType[id="${lnType}"] > DO[name="${parentName}"]`,
-    );
-    let parentType = parentElt?.getAttribute('type') as string;
-
-    let i = 1;
-    for (; i < path.length; i += 1) {
-      parentName = path[i].name;
-      parentElt = this.doc?.querySelector(
-        `:root > DataTypeTemplates > *[id="${parentType}"] > *[name="${parentName}"]`,
-      );
-
-      if (i === path.length - 1) break;
-
-      parentType = parentElt?.getAttribute('type') as string;
-    }
-
-    return parentElt ?? null;
   }
 
   private deleteLN(ln: Element) {
@@ -593,8 +434,17 @@ export class IedEditor extends LitElement {
     const isSettingAttr = ['SG', 'SE'].includes(
       da.getAttribute('fc') as string,
     );
+
     if (!isSettingAttr) {
-      this.addValue(ln, path, this.getTemplateValue(ln, path) as string);
+      this.addValue(
+        ln,
+        path,
+        getTemplateValue(
+          this.dataTypeTemplates,
+          ln.getAttribute('lnType') as string,
+          path,
+        ) as string,
+      );
       return;
     }
 
@@ -602,7 +452,11 @@ export class IedEditor extends LitElement {
       this.addValue(
         ln,
         path,
-        this.getTemplateValue(ln, path) as string,
+        getTemplateValue(
+          this.dataTypeTemplates,
+          ln.getAttribute('lnType') as string,
+          path,
+        ) as string,
         i.toString(),
       );
     }
@@ -647,6 +501,21 @@ export class IedEditor extends LitElement {
     this.dispatchEvent(newEditEventV2(editMissingValues));
   }
 
+  private renderDescription(
+    target: Element,
+    host?: Element,
+    path: { name: string; tag: string }[] = [],
+  ) {
+    const desc =
+      getInstanceDescription(target, host, path) ||
+      getTemplateDescription(this.dataTypeTemplates, target);
+    if (desc) {
+      return html`<p class="desc">${desc}</p>`;
+    }
+
+    return nothing;
+  }
+
   private renderValueInputField(
     value: Element,
     ln: Element,
@@ -658,17 +527,18 @@ export class IedEditor extends LitElement {
     const sGroup = value.getAttribute('sGroup') || '';
     const label = isActSG ? `Val ${sGroup} (actSG)` : `Val ${sGroup ?? ''}`;
     const elementID = getInputPath(ln, path, sGroup || index);
-    const parentDA = this.getMostNestedElt(
-      path,
+    const parentDA = getMostNestedElement(
+      this.dataTypeTemplates,
       ln.getAttribute('lnType') as string,
+      path,
     );
     const bType = parentDA?.getAttribute('bType');
 
     // if it is an enum type, get the ordinal numbers and string labels
     if (bType === 'Enum') {
       const enumType = parentDA?.getAttribute('type');
-      const enumTypeElement = this.doc?.querySelector(
-        `:root > DataTypeTemplates > EnumType[id="${enumType}"]`,
+      const enumTypeElement = this.dataTypeTemplates?.querySelector(
+        `:scope > EnumType[id="${enumType}"]`,
       );
 
       const enumVals = enumTypeElement?.querySelectorAll('EnumVal') as NodeList;
@@ -706,9 +576,10 @@ export class IedEditor extends LitElement {
     actSG: number,
     path: { name: string; tag: string }[],
   ) {
-    const parentDA = this.getMostNestedElt(
-      path,
+    const parentDA = getMostNestedElement(
+      this.dataTypeTemplates,
       ln.getAttribute('lnType') as string,
+      path,
     );
     const parentFC = parentDA?.getAttribute('fc') as string;
     const readOnly =
@@ -840,8 +711,11 @@ export class IedEditor extends LitElement {
                       this.addValue(
                         ln,
                         path,
-                        (this.getTemplateValue(ln, path) as string) ||
-                          (activeValue?.textContent as string),
+                        (getTemplateValue(
+                          this.dataTypeTemplates,
+                          ln.getAttribute('lnType') as string,
+                          path,
+                        ) as string) || (activeValue?.textContent as string),
                         i.toString(),
                       );
                     }}
@@ -968,7 +842,7 @@ export class IedEditor extends LitElement {
               </div>
             </summary>
 
-            ${this.getInstanceDescription(
+            ${this.renderDescription(
               key,
               ln,
               path.concat({
@@ -1003,8 +877,8 @@ export class IedEditor extends LitElement {
   }
 
   private renderLN(ln: Element, numOfSGs: number, actSG: number) {
-    const lnType = this.doc?.querySelector(
-      `:root > DataTypeTemplates > LNodeType[id="${ln.getAttribute('lnType')}"]`,
+    const lnType = this.dataTypeTemplates?.querySelector(
+      `:scope > LNodeType[id="${ln.getAttribute('lnType')}"]`,
     ) as Element;
     if (!lnType) return nothing;
 
@@ -1046,7 +920,7 @@ export class IedEditor extends LitElement {
             </div>
           </div>
         </summary>
-        ${this.getInstanceDescription(ld)}
+        ${this.renderDescription(ld)}
         ${Array.from(ld.querySelectorAll(':scope > LN0, :scope > LN'))
           .filter(
             ln =>
@@ -1088,7 +962,7 @@ export class IedEditor extends LitElement {
                     </div>
                   </div>
                 </summary>
-                ${this.getInstanceDescription(ln)}
+                ${this.renderDescription(ln)}
                 ${this.renderLN(ln, numOfSGs, actSG)}
               </details>
             `,
@@ -1173,7 +1047,7 @@ export class IedEditor extends LitElement {
                       </div>
                     </div>
                   </summary>
-                  ${this.getInstanceDescription(server.parentElement!)}
+                  ${this.renderDescription(server.parentElement!)}
                   ${Array.from(server.querySelectorAll(':scope > LDevice'))
                     .filter(
                       ld =>

--- a/src/ied-editor.ts
+++ b/src/ied-editor.ts
@@ -11,6 +11,16 @@ import {
   SetTextContent,
 } from '@omicronenergy/oscd-api';
 import { newEditEventV2 } from '@omicronenergy/oscd-api/utils.js';
+import {
+  dataModelPathCache,
+  DataModel,
+  debounce,
+  getDataModel,
+  getInitializedEltPath,
+  matchesLNToken,
+  matchesNameToken,
+  pathHasPrefixAndTokens,
+} from './utils/ied-data-model.js';
 
 import 'mbg-val-input/mbg-val-input.js';
 import './components/alert-dialog.js';
@@ -26,22 +36,7 @@ import '@material/web/progress/circular-progress.js';
 import '@material/web/dialog/dialog.js';
 import '@material/web/button/text-button.js';
 
-const cache = new WeakMap();
-
-type DataModel = Map<Element, DataModel>;
-
 type Values = Map<Element, Values | Element[]>;
-
-function debounce(callback: (...args: unknown[]) => void, delay = 100) {
-  let timeout: number;
-
-  return (...args: unknown[]) => {
-    clearTimeout(timeout);
-    timeout = window.setTimeout(() => {
-      callback(...args);
-    }, delay);
-  };
-}
 
 function handleModelExpand(e: Event) {
   const button = e.target as HTMLButtonElement;
@@ -71,25 +66,6 @@ function handleModelExpand(e: Event) {
       }
     }
   }
-}
-
-function getInitializedEltPath(element: Element): string {
-  let path = [`${element.getAttribute('name')}`];
-
-  // traverse through parent elements until an LN is found
-  let parentElt = element.parentElement as Element;
-  while (parentElt) {
-    if (parentElt.tagName === 'LN' || parentElt.tagName === 'LN0') {
-      path = [`${parentElt.tagName} ${identity(parentElt)}`].concat(path);
-      break;
-    }
-    path = [`${parentElt.getAttribute('name')}`].concat(path);
-    parentElt = parentElt.parentNode as Element;
-  }
-
-  const stringPath = path.join(' ');
-
-  return stringPath;
 }
 
 function getInputPath(
@@ -178,49 +154,6 @@ function getValues(
   return values;
 }
 
-function getDataModel(dataType: Element, path: string[]): DataModel {
-  // a datatype can have multiple paths
-  const stringPath = path.join(' ');
-  if (!cache.has(dataType)) {
-    cache.set(dataType, new Set());
-  }
-  if (!cache.get(dataType).has(stringPath)) {
-    cache.get(dataType).add(stringPath);
-  }
-
-  const children = Array.from(dataType.children).filter(child =>
-    ['DO', 'DA', 'SDO', 'BDA'].includes(child.tagName),
-  );
-  const dataModel = new Map<Element, DataModel>();
-
-  for (const child of children) {
-    if (!cache.has(child)) {
-      cache.set(child, new Set());
-    }
-    const childStringPath = path
-      .concat(child.getAttribute('name') as string)
-      .join(' ');
-    if (!cache.get(child).has(childStringPath)) {
-      cache.get(child).add(childStringPath);
-    }
-
-    const childType = dataType
-      ?.closest('DataTypeTemplates')
-      ?.querySelector(`:scope > [id="${child.getAttribute('type')}"]`);
-    if (childType)
-      dataModel.set(
-        child,
-        getDataModel(
-          childType,
-          path.concat(child.getAttribute('name') as string),
-        ),
-      );
-    else dataModel.set(child, new Map());
-  }
-
-  return dataModel;
-}
-
 function getSGCB(ld: Element): Element | null {
   if (ld.querySelector(':scope > LN0 > SettingControl')) {
     return ld.querySelector(':scope > LN0 > SettingControl') as Element;
@@ -261,47 +194,6 @@ function isReadOnly(da: Element | null): boolean {
 
   const canImport = (da.getAttribute('valImport') as string) === 'false';
   return isKindRO && canImport;
-}
-
-function matchesLNToken(ln: Element, token: string): boolean {
-  if (token === '*') return true;
-  const lower = token.toLowerCase();
-  const lnClass = (ln.getAttribute('lnClass') ?? '').toLowerCase();
-  const inst = (ln.getAttribute('inst') ?? '').toLowerCase();
-  return (
-    lnClass.includes(lower) ||
-    inst.includes(lower) ||
-    `${lnClass}${inst}`.includes(lower)
-  );
-}
-
-function matchesNameToken(element: Element, token: string): boolean {
-  if (token === '*') return true;
-  return (element.getAttribute('name') ?? '')
-    .toLowerCase()
-    .includes(token.toLowerCase());
-}
-
-function pathHasPrefixAndTokens(
-  path: string,
-  lnPath: string,
-  nameTokens: string[],
-): boolean {
-  // Check whether a cached path string matches a known LN path prefix
-  if (!path.startsWith(lnPath)) return false;
-
-  // If there are no name tokens, any path with the correct LN prefix matches
-  if (nameTokens.length === 0) return path.length > lnPath.length;
-
-  // Split the remainder of the path into tokens and check for matches in order
-  const remainder = path.slice(lnPath.length + 1); // +1 to skip the separating space
-  const nameParts = remainder.split(' ');
-
-  return nameTokens.every((token, i) => {
-    const part = nameParts[i];
-    if (!part) return false;
-    return token === '*' || part.toLowerCase().includes(token.toLowerCase());
-  });
 }
 
 export class IedEditor extends LitElement {
@@ -482,7 +374,9 @@ export class IedEditor extends LitElement {
     Array.from(
       this.doc.querySelectorAll(':root > DataTypeTemplates *'),
     ).forEach(element => {
-      const cachedPaths = cache.get(element) as Set<string> | undefined;
+      const cachedPaths = dataModelPathCache.get(element) as
+        | Set<string>
+        | undefined;
       if (!cachedPaths || cachedPaths.size === 0) return;
       [...cachedPaths].forEach(path => {
         if (
@@ -534,7 +428,9 @@ export class IedEditor extends LitElement {
         } else if (['DOI', 'SDI', 'DAI'].includes(element.tagName)) {
           addPath(getInitializedEltPath(element));
         }
-        cache.get(element)?.forEach((path: string) => addPath(path));
+        dataModelPathCache
+          .get(element)
+          ?.forEach((path: string) => addPath(path));
       });
     }
 

--- a/src/ied-editor.ts
+++ b/src/ied-editor.ts
@@ -14,6 +14,9 @@ import { newEditEventV2 } from '@omicronenergy/oscd-api/utils.js';
 
 import {
   DataModel,
+  Values,
+  hasValues,
+  getValues,
   getDataModel,
   getInitializedEltPath,
 } from './utils/ied-data-model.js';
@@ -32,8 +35,6 @@ import '@material/web/icon/icon.js';
 import '@material/web/progress/circular-progress.js';
 import '@material/web/dialog/dialog.js';
 import '@material/web/button/text-button.js';
-
-type Values = Map<Element, Values | Element[]>;
 
 function handleModelExpand(e: Event) {
   const button = e.target as HTMLButtonElement;
@@ -109,46 +110,6 @@ function findInstanceToRemove(element: Element) {
   }
 
   return findInstanceToRemove(parent);
-}
-
-function hasValues(values: Values | Element[] | undefined): boolean {
-  return Array.isArray(values) && values.length > 0;
-}
-
-function getValues(
-  instance: Element,
-  dataModel: DataModel,
-): Values | Element[] {
-  // instance -> DOI -> SDI* -> DAI -> Val
-  const childVals = Array.from(instance.children).filter(
-    child => child.tagName === 'Val',
-  );
-  if (childVals.length > 0) {
-    return childVals;
-  }
-
-  const children = Array.from(instance.children).filter(child =>
-    ['DOI', 'SDI', 'DAI'].includes(child.tagName),
-  );
-
-  const childNames = children.map(child => child.getAttribute('name'));
-  const values = new Map<Element, Values | Element[]>();
-
-  dataModel.forEach((value: DataModel, key: Element) => {
-    if (childNames.includes(key.getAttribute('name'))) {
-      values.set(
-        key,
-        getValues(
-          children.find(
-            child => child.getAttribute('name') === key.getAttribute('name'),
-          ) as Element,
-          value,
-        ),
-      );
-    }
-  });
-
-  return values;
 }
 
 function getSGCB(ld: Element): Element | null {

--- a/src/utils/ied-data-model.ts
+++ b/src/utils/ied-data-model.ts
@@ -4,12 +4,54 @@ export const dataModelPathCache = new WeakMap();
 
 export type DataModel = Map<Element, DataModel>;
 
+export type Values = Map<Element, Values | Element[]>;
+
 export function debounce(callback: (...args: unknown[]) => void, delay = 100) {
   let timeout: number;
   return (...args: unknown[]) => {
     clearTimeout(timeout);
     timeout = window.setTimeout(() => callback(...args), delay);
   };
+}
+
+export function hasValues(values: Values | Element[] | undefined): boolean {
+  return Array.isArray(values) && values.length > 0;
+}
+
+export function getValues(
+  instance: Element,
+  dataModel: DataModel,
+): Values | Element[] {
+  // instance -> DOI -> SDI* -> DAI -> Val
+  const childVals = Array.from(instance.children).filter(
+    child => child.tagName === 'Val',
+  );
+  if (childVals.length > 0) {
+    return childVals;
+  }
+
+  const children = Array.from(instance.children).filter(child =>
+    ['DOI', 'SDI', 'DAI'].includes(child.tagName),
+  );
+
+  const childNames = children.map(child => child.getAttribute('name'));
+  const values = new Map<Element, Values | Element[]>();
+
+  dataModel.forEach((value: DataModel, key: Element) => {
+    if (childNames.includes(key.getAttribute('name'))) {
+      values.set(
+        key,
+        getValues(
+          children.find(
+            child => child.getAttribute('name') === key.getAttribute('name'),
+          ) as Element,
+          value,
+        ),
+      );
+    }
+  });
+
+  return values;
 }
 
 export function getInitializedEltPath(element: Element): string {

--- a/src/utils/ied-data-model.ts
+++ b/src/utils/ied-data-model.ts
@@ -1,0 +1,116 @@
+import { identity } from '@openenergytools/scl-lib';
+
+export const dataModelPathCache = new WeakMap();
+
+export type DataModel = Map<Element, DataModel>;
+
+export function debounce(callback: (...args: unknown[]) => void, delay = 100) {
+  let timeout: number;
+  return (...args: unknown[]) => {
+    clearTimeout(timeout);
+    timeout = window.setTimeout(() => callback(...args), delay);
+  };
+}
+
+export function getInitializedEltPath(element: Element): string {
+  let path = [`${element.getAttribute('name')}`];
+
+  // traverse through parent elements until an LN is found
+  let parentElt = element.parentElement as Element;
+  while (parentElt) {
+    if (parentElt.tagName === 'LN' || parentElt.tagName === 'LN0') {
+      path = [`${parentElt.tagName} ${identity(parentElt)}`].concat(path);
+      break;
+    }
+    path = [`${parentElt.getAttribute('name')}`].concat(path);
+    parentElt = parentElt.parentNode as Element;
+  }
+
+  return path.join(' ');
+}
+
+export function getDataModel(dataType: Element, path: string[]): DataModel {
+  // a datatype can have multiple paths - store to avoid duplicates
+  const stringPath = path.join(' ');
+  if (!dataModelPathCache.has(dataType)) {
+    dataModelPathCache.set(dataType, new Set());
+  }
+  if (!dataModelPathCache.get(dataType).has(stringPath)) {
+    dataModelPathCache.get(dataType).add(stringPath);
+  }
+
+  const children = Array.from(dataType.children).filter(child =>
+    ['DO', 'DA', 'SDO', 'BDA'].includes(child.tagName),
+  );
+  const dataModel = new Map<Element, DataModel>();
+
+  for (const child of children) {
+    if (!dataModelPathCache.has(child)) {
+      dataModelPathCache.set(child, new Set());
+    }
+
+    const childStringPath = path
+      .concat(child.getAttribute('name') as string)
+      .join(' ');
+    if (!dataModelPathCache.get(child).has(childStringPath)) {
+      dataModelPathCache.get(child).add(childStringPath);
+    }
+
+    const childType = dataType
+      ?.closest('DataTypeTemplates')
+      ?.querySelector(`:scope > [id="${child.getAttribute('type')}"]`);
+    if (childType) {
+      dataModel.set(
+        child,
+        getDataModel(
+          childType,
+          path.concat(child.getAttribute('name') as string),
+        ),
+      );
+    } else {
+      dataModel.set(child, new Map());
+    }
+  }
+
+  return dataModel;
+}
+
+export function matchesLNToken(ln: Element, token: string): boolean {
+  if (token === '*') return true;
+  const lower = token.toLowerCase();
+  const lnClass = (ln.getAttribute('lnClass') ?? '').toLowerCase();
+  const inst = (ln.getAttribute('inst') ?? '').toLowerCase();
+  return (
+    lnClass.includes(lower) ||
+    inst.includes(lower) ||
+    `${lnClass}${inst}`.includes(lower)
+  );
+}
+
+export function matchesNameToken(element: Element, token: string): boolean {
+  if (token === '*') return true;
+  return (element.getAttribute('name') ?? '')
+    .toLowerCase()
+    .includes(token.toLowerCase());
+}
+
+export function pathHasPrefixAndTokens(
+  path: string,
+  lnPath: string,
+  nameTokens: string[],
+): boolean {
+  // Check whether a cached path string matches a known LN path prefix
+  if (!path.startsWith(lnPath)) return false;
+
+  // If there are no name tokens, any path with the correct LN prefix matches
+  if (nameTokens.length === 0) return path.length > lnPath.length;
+
+  // Split the remainder of the path into tokens and check for matches in order
+  const remainder = path.slice(lnPath.length + 1);
+  const nameParts = remainder.split(' ');
+  return nameTokens.every((token, i) => {
+    const part = nameParts[i];
+    if (!part) return false;
+    return token === '*' || part.toLowerCase().includes(token.toLowerCase());
+  });
+}

--- a/src/utils/ied-scl.ts
+++ b/src/utils/ied-scl.ts
@@ -1,0 +1,174 @@
+export function findInstanceToRemove(element: Element) {
+  const parent = element.parentElement as Element;
+  const siblings = Array.from(parent.children).filter(
+    child => child.tagName === element.tagName,
+  );
+
+  if (siblings.length > 1 || !['DOI', 'SDI', 'DAI'].includes(parent.tagName)) {
+    return element;
+  }
+
+  return findInstanceToRemove(parent);
+}
+
+export function getInputPath(
+  ln: Element,
+  path: { name: string; tag: string }[],
+  sGroup: string,
+) {
+  const parentLD = (ln.parentNode as Element)?.getAttribute('inst');
+  const lnClass = ln.getAttribute('lnClass');
+  const lnInst = ln.getAttribute('inst');
+
+  let elementID = `${parentLD}-${lnClass}${lnInst}`;
+  for (let i = 0; i < path.length; i += 1) {
+    elementID += `-${path[i].name}`;
+    if (i === path.length - 1) elementID += sGroup;
+  }
+
+  return elementID;
+}
+
+export function getInstanceDescription(
+  target: Element,
+  host?: Element,
+  path: { name: string; tag: string }[] = [],
+) {
+  let instantiatedDesc = '';
+
+  // if the instance is in a path, check if it has a description in the IED
+  if (path.length > 0 && host) {
+    let childInstance = host.querySelector(
+      `:scope > DOI[name="${path[0].name}"]`,
+    );
+    for (let i = 1; i < path.length && childInstance; i += 1) {
+      childInstance = childInstance.querySelector(
+        `:scope > *[name="${path[i].name}"]`,
+      );
+    }
+
+    if (childInstance?.getAttribute('name') === target.getAttribute('name')) {
+      instantiatedDesc = childInstance?.getAttribute('desc') ?? '';
+    }
+  }
+
+  if (instantiatedDesc) return instantiatedDesc;
+
+  return target.getAttribute('desc') ?? '';
+}
+
+export function getMostNestedElement(
+  template: Element,
+  lnType: string,
+  path: { name: string; tag: string }[],
+): Element | null {
+  let parentName = path[0].name;
+  let parentElt = template?.querySelector(
+    `:scope > LNodeType[id="${lnType}"] > DO[name="${parentName}"]`,
+  );
+  let parentType = parentElt?.getAttribute('type') as string;
+
+  let i = 1;
+  for (; i < path.length; i += 1) {
+    parentName = path[i].name;
+    parentElt = template?.querySelector(
+      `:scope > *[id="${parentType}"] > *[name="${parentName}"]`,
+    );
+
+    if (i === path.length - 1) break;
+
+    parentType = parentElt?.getAttribute('type') as string;
+  }
+
+  return parentElt ?? null;
+}
+
+export function getSGCB(ld: Element): Element | null {
+  if (ld.querySelector(':scope > LN0 > SettingControl')) {
+    return ld.querySelector(':scope > LN0 > SettingControl') as Element;
+  }
+
+  if (!ld.querySelector(':scope > LN0 > DOI[name="GrRef"]')) {
+    return null;
+  }
+
+  const setSrcRef = ld.querySelector(
+    ':scope > LN0 > DOI[name="GrRef"] > DAI[name="setSrcRef"] > Val',
+  );
+  const sgcbRef = setSrcRef?.textContent?.trim().replace(/^@/, '') ?? '';
+  const ldRef = ld
+    .closest('Server')!
+    .querySelector(`:scope > LDevice[inst="${sgcbRef}"]`);
+
+  return getSGCB(ldRef as Element);
+}
+
+export function getTemplateDescription(template: Element, target: Element) {
+  if (!template) return '';
+
+  let instTemplate = null;
+  if (target.nodeName === 'LN' || target.nodeName === 'LN0') {
+    instTemplate = template?.querySelector(
+      `:scope > LNodeType[id="${target.getAttribute('lnType')}"]`,
+    );
+  } else if (target.nodeName !== 'LDevice') {
+    instTemplate = template?.querySelector(
+      `:scope > *[id="${target.getAttribute('type')}"]`,
+    );
+  }
+
+  return instTemplate?.getAttribute('desc') ?? '';
+}
+
+export function getTemplateValue(
+  template: Element,
+  lnType: string,
+  path: { name: string; tag: string }[],
+) {
+  if (!template) return '';
+
+  const lnTemplate = template?.querySelector(
+    `:scope > LNodeType[id="${lnType}"]`,
+  );
+  let nestedInst = lnTemplate?.querySelector(
+    `:scope > *[name="${path[0].name}"]`,
+  );
+
+  for (let i = 1; i < path.length; i += 1) {
+    const instType = nestedInst?.getAttribute('type');
+    const instTemplate = template?.querySelector(
+      `:scope > *[id="${instType}"]`,
+    );
+    nestedInst = instTemplate?.querySelector(
+      `:scope > *[name="${path[i].name}"]`,
+    );
+  }
+
+  if (nestedInst?.querySelector('Val')) {
+    return nestedInst?.querySelector('Val')?.textContent;
+  }
+
+  return '';
+}
+
+export function isReadOnly(da: Element | null): boolean {
+  if (!da) return false;
+
+  const isKindRO = (da.getAttribute('valKind') as string) === 'RO';
+  if (!da.getAttribute('valImport')) return isKindRO;
+
+  const canImport = (da.getAttribute('valImport') as string) === 'false';
+  return isKindRO && canImport;
+}
+
+export function setTag(key: Element) {
+  let tag = 'DAI';
+
+  if (key.tagName === 'DO') {
+    tag = 'DOI';
+  } else if (key.tagName === 'SDO' || key.getAttribute('bType') === 'Struct') {
+    tag = 'SDI';
+  }
+
+  return tag;
+}


### PR DESCRIPTION
Separate the search filter into its own component.
Move data model parsing into its own utility.
Move SCL parsing into its own utility.